### PR TITLE
Add strict mode declaration to the top of index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const nefHandler = {
   get(target, name) {
     if (!target[name]) target[name] = {};


### PR DESCRIPTION
This was causing the following error:

`SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`

to be printed to the console.